### PR TITLE
Debug info

### DIFF
--- a/compile/compile.lisp
+++ b/compile/compile.lisp
@@ -395,19 +395,17 @@
 
 (defun emit-call (context count)
   (let ((receiving (context-receiving context)))
-    (cond ((or (eql receiving t) (eql receiving 0))
-           (assemble context m:call count))
-          ((eql receiving 1)
-           (assemble context m:call-receive-one count))
-          (t (assemble context m:call-receive-fixed count receiving)))))
+    (case receiving
+      ((t) (assemble context m:call count))
+      ((1) (assemble context m:call-receive-one count))
+      (t   (assemble context m:call-receive-fixed count receiving)))))
 
 (defun emit-mv-call (context)
   (let ((receiving (context-receiving context)))
-    (cond ((or (eql receiving t) (eql receiving 0))
-           (assemble context m:mv-call))
-          ((eql receiving 1)
-           (assemble context m:mv-call-receive-one))
-          (t (assemble context m:mv-call-receive-fixed receiving)))))
+    (case receiving
+      ((t) (assemble context m:mv-call))
+      ((1) (assemble context m:mv-call-receive-one))
+      (t   (assemble context m:mv-call-receive-fixed receiving)))))
 
 (defun emit-special-bind (context symbol)
   (assemble context m:special-bind (value-cell-index symbol context)))

--- a/compile/compile.lisp
+++ b/compile/compile.lisp
@@ -500,143 +500,8 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; Environments
+;;; Environments (mostly in environment.lisp)
 ;;;
-
-(defstruct (lexical-environment (:constructor make-null-lexical-environment
-                                    (global-environment))
-                                (:constructor %make-lexical-environment)
-                                (:conc-name nil))
-  ;; An alist of (var . var-info) in the current environment.
-  (vars nil :type list :read-only t)
-  ;; An alist of (tag tag-dynenv . label) in the current environment.
-  (tags nil :type list :read-only t)
-  ;; An alist of (block block-dynenv . label) in the current environment.
-  (blocks nil :type list :read-only t)
-  ;; An alist of (fun . fun-var) in the current environment.
-  (funs nil :type list :read-only t)
-  ;; Global environment, which we just pass to Trucler.
-  (global-environment (error "missing arg") :read-only t))
-
-;;; We don't use Trucler's augmentation protocol internally since we often
-;;; want to add a bunch of stuff at once, which is awkward in Trucler.
-(defun make-lexical-environment (parent &key (vars (vars parent))
-                                          (tags (tags parent))
-                                          (blocks (blocks parent))
-                                          (funs (funs parent)))
-  (%make-lexical-environment
-   :vars vars :tags tags :blocks blocks :funs funs
-   :global-environment (global-environment parent)))
-
-(defun make-null-lexenv (global-compilation-environment)
-  (%make-lexical-environment
-   :global-environment global-compilation-environment))
-
-;;; We don't actually use Trucler's query protocol internally, since the
-;;; environments are necessarily ours (they include bytecode-specific
-;;; information, etc.)
-;;; But we do fall back to it when we hit the global environment.
-;;; And we define the methods, to be nice to macros, so maybe we
-;;; should use it internally after all.
-;;; TODO: Once trucler actually implements augmentation we should
-;;; maybe use that and not have our own environments at all.
-
-(defmethod trucler:global-environment (client (env lexical-environment))
-  (declare (ignore client))
-  (global-environment env))
-
-(defmethod trucler:describe-variable
-    (client (env lexical-environment) name)
-  (or (cdr (assoc name (vars env)))
-      (trucler:describe-variable client
-                                 (global-environment env) name)))
-
-(defmethod trucler:describe-function
-    (client (env lexical-environment) name)
-  (or (cdr (assoc name (funs env) :test #'equal))
-      (trucler:describe-variable client
-                                 (global-environment env) name)))
-
-(defmethod trucler:describe-block
-    (client (env lexical-environment) name)
-  (cdr (assoc name (blocks env))))
-
-(defmethod trucler:describe-tag
-    (client (env lexical-environment) name)
-  (cdr (assoc name (tags env))))
-
-(defun var-info (name env)
-  (or (cdr (assoc name (vars env)))
-      (trucler:describe-variable m:*client* (global-environment env) name)))
-(defun fun-info (name env)
-  (or (cdr (assoc name (funs env) :test #'equal))
-      (trucler:describe-function m:*client* (global-environment env) name)))
-
-;; never actually called
-(defun missing-arg () (error "missing arg"))
-
-;;; Our info for lexical bindings (variable and function).
-(defstruct (lexical-info
-            (:constructor make-lexical-info
-                (frame-offset cfunction)))
-  ;; Register index for this lvar.
-  (frame-offset (missing-arg) :read-only t :type (integer 0))
-  ;; Cfunction this lvar belongs to (i.e. is bound by)
-  (cfunction (missing-arg) :read-only t :type cfunction))
-
-;;; Our info for specifically variable bindings.
-;;; (while function bindings can be closed over, they can't be modified,
-;;;  so we don't really care.)
-(defstruct (lexical-variable-info
-            (:constructor make-lexical-variable-info
-                (frame-offset cfunction))
-            (:include lexical-info))
-  (closed-over-p nil :type boolean)
-  (setp nil :type boolean))
-
-(defun frame-offset (lex-desc)
-  (lexical-info-frame-offset (trucler:identity lex-desc)))
-
-(defun lvar-cfunction (lex-desc)
-  (lexical-info-cfunction (trucler:identity lex-desc)))
-
-(defun closed-over-p (lvar-desc)
-  (lexical-variable-info-closed-over-p (trucler:identity lvar-desc)))
-
-(defun (setf closed-over-p) (new lvar-desc)
-  (setf (lexical-variable-info-closed-over-p (trucler:identity lvar-desc))
-        new))
-
-(defun setp (lvar-desc)
-  (lexical-variable-info-setp (trucler:identity lvar-desc)))
-
-(defun (setf setp) (new lvar-desc)
-  (setf (lexical-variable-info-setp (trucler:identity lvar-desc)) new))
-
-;;; Does the lexical variable need a cell?
-(defun indirect-lexical-p (lvar)
-  (and (closed-over-p lvar) (setp lvar)))
-
-(defun make-lexical-variable (name frame-offset cfunction)
-  (make-instance 'trucler:lexical-variable-description
-    :name name
-    :identity (make-lexical-variable-info frame-offset cfunction)))
-
-(defun make-symbol-macro (name expansion)
-  (make-instance 'trucler:symbol-macro-description
-    :name name :expansion expansion))
-
-(defun globally-special-p (symbol env)
-  (typep (var-info symbol env) 'trucler:global-special-variable-description))
-
-(defun make-local-function (name frame-offset cfunction)
-  (make-instance 'trucler:local-function-description
-    :name name
-    :identity (make-lexical-info frame-offset cfunction)))
-
-(defun make-local-macro (name expander)
-  (make-instance 'trucler:local-macro-description
-    :name name :expander expander))
 
 ;;; Bind each variable to a stack location, returning a new lexical
 ;;; environment and new context.
@@ -673,12 +538,6 @@
         ((>= index frame-end)
          (values (make-lexical-environment env :funs new-vars)
                  (new-context context :frame-end frame-end))))))
-
-(defun add-macros (env macros)
-  (make-lexical-environment env :funs (append macros (funs env))))
-
-(defun add-symbol-macros (env symbol-macros)
-  (make-lexical-environment env :vars (append symbol-macros (vars env))))
 
 (deftype lambda-expression () '(cons (eql lambda) (cons list list)))
 (deftype function-name () '(or symbol (cons (eql setf) (cons symbol null))))

--- a/compile/conditions.lisp
+++ b/compile/conditions.lisp
@@ -1,0 +1,20 @@
+(in-package #:maclina.compile)
+
+(define-condition compiler-condition (condition)
+  ((%source :initarg :source :initform nil :reader source)))
+
+(defmethod source ((condition condition)) nil)
+
+(define-condition program-condition (condition) ())
+
+(define-condition compiler-program-error (program-condition program-error
+                                          compiler-condition)
+  ())
+
+(define-condition compiler-program-warning (program-condition warning
+                                            compiler-condition)
+  ())
+
+(define-condition compiler-program-style-warning
+    (program-condition style-warning compiler-condition)
+  ())

--- a/compile/environment.lisp
+++ b/compile/environment.lisp
@@ -1,0 +1,140 @@
+(in-package #:maclina.compile)
+
+;; never actually called
+(defun missing-arg () (error "missing arg"))
+
+(defstruct (lexical-environment (:constructor make-null-lexical-environment
+                                    (global-environment))
+                                (:constructor %make-lexical-environment)
+                                (:conc-name nil))
+  ;; An alist of (var . lvar-desc) in the current environment.
+  (vars nil :type list :read-only t)
+  ;; An alist of (tag dynenv-desc . label) in the current environment.
+  (tags nil :type list :read-only t)
+  ;; An alist of (block block-dynenv . label) in the current environment.
+  (blocks nil :type list :read-only t)
+  ;; An alist of (fun . lfun-desc) in the current environment.
+  (funs nil :type list :read-only t)
+  ;; Global environment, which we just pass to Trucler.
+  (global-environment (missing-arg) :read-only t))
+
+;;; We don't use Trucler's augmentation protocol internally since we often
+;;; want to add a bunch of stuff at once, which is awkward in Trucler.
+(defun make-lexical-environment (parent &key (vars (vars parent))
+                                          (tags (tags parent))
+                                          (blocks (blocks parent))
+                                          (funs (funs parent)))
+  (%make-lexical-environment
+   :vars vars :tags tags :blocks blocks :funs funs
+   :global-environment (global-environment parent)))
+
+(defun make-null-lexenv (global-compilation-environment)
+  (%make-lexical-environment
+   :global-environment global-compilation-environment))
+
+;;; We don't actually use Trucler's query protocol internally, since the
+;;; environments are necessarily ours (they include bytecode-specific
+;;; information, etc.)
+;;; But we do fall back to it when we hit the global environment.
+;;; And we define the methods, to be nice to macros, so maybe we
+;;; should use it internally after all.
+;;; TODO: Once trucler actually implements augmentation we should
+;;; maybe use that and not have our own environments at all.
+
+(defmethod trucler:global-environment (client (env lexical-environment))
+  (declare (ignore client))
+  (global-environment env))
+
+(defmethod trucler:describe-variable
+    (client (env lexical-environment) name)
+  (or (cdr (assoc name (vars env)))
+      (trucler:describe-variable client (global-environment env) name)))
+
+(defmethod trucler:describe-function
+    (client (env lexical-environment) name)
+  (or (cdr (assoc name (funs env) :test #'equal))
+      (trucler:describe-function client (global-environment env) name)))
+
+(defmethod trucler:describe-block
+    (client (env lexical-environment) name)
+  (cdr (assoc name (blocks env))))
+
+(defmethod trucler:describe-tag
+    (client (env lexical-environment) name)
+  (cdr (assoc name (tags env))))
+
+(defun var-info (name env)
+  (or (cdr (assoc name (vars env)))
+      (trucler:describe-variable m:*client* (global-environment env) name)))
+(defun fun-info (name env)
+  (or (cdr (assoc name (funs env) :test #'equal))
+      (trucler:describe-function m:*client* (global-environment env) name)))
+
+;;; Our info for lexical bindings (variable and function).
+(defstruct (lexical-info
+            (:constructor make-lexical-info
+                (frame-offset cfunction)))
+  ;; Register index for this lvar.
+  (frame-offset (missing-arg) :read-only t :type (integer 0))
+  ;; Cfunction this lvar belongs to (i.e. is bound by)
+  (cfunction (missing-arg) :read-only t :type cfunction))
+
+;;; Our info for specifically variable bindings.
+;;; (while function bindings can be closed over, they can't be modified,
+;;;  so we don't really care.)
+(defstruct (lexical-variable-info
+            (:constructor make-lexical-variable-info
+                (frame-offset cfunction))
+            (:include lexical-info))
+  (closed-over-p nil :type boolean)
+  (setp nil :type boolean))
+
+(defun frame-offset (lex-desc)
+  (lexical-info-frame-offset (trucler:identity lex-desc)))
+
+(defun lvar-cfunction (lex-desc)
+  (lexical-info-cfunction (trucler:identity lex-desc)))
+
+(defun closed-over-p (lvar-desc)
+  (lexical-variable-info-closed-over-p (trucler:identity lvar-desc)))
+
+(defun (setf closed-over-p) (new lvar-desc)
+  (setf (lexical-variable-info-closed-over-p (trucler:identity lvar-desc))
+        new))
+
+(defun setp (lvar-desc)
+  (lexical-variable-info-setp (trucler:identity lvar-desc)))
+
+(defun (setf setp) (new lvar-desc)
+  (setf (lexical-variable-info-setp (trucler:identity lvar-desc)) new))
+
+;;; Does the lexical variable need a cell?
+(defun indirect-lexical-p (lvar)
+  (and (closed-over-p lvar) (setp lvar)))
+
+(defun make-lexical-variable (name frame-offset cfunction)
+  (make-instance 'trucler:lexical-variable-description
+    :name name
+    :identity (make-lexical-variable-info frame-offset cfunction)))
+
+(defun make-symbol-macro (name expansion)
+  (make-instance 'trucler:symbol-macro-description
+    :name name :expansion expansion))
+
+(defun globally-special-p (symbol env)
+  (typep (var-info symbol env) 'trucler:global-special-variable-description))
+
+(defun make-local-function (name frame-offset cfunction)
+  (make-instance 'trucler:local-function-description
+    :name name
+    :identity (make-lexical-info frame-offset cfunction)))
+
+(defun make-local-macro (name expander)
+  (make-instance 'trucler:local-macro-description
+    :name name :expander expander))
+
+(defun add-macros (env macros)
+  (make-lexical-environment env :funs (append macros (funs env))))
+
+(defun add-symbol-macros (env symbol-macros)
+  (make-lexical-environment env :vars (append symbol-macros (vars env))))

--- a/compile/misc-program-conditions.lisp
+++ b/compile/misc-program-conditions.lisp
@@ -41,6 +41,29 @@
              (format stream "~s is not a valid variable name"
                      (name condition)))))
 
+(define-condition used (style-warning)
+  ((%name :initarg :name :reader name)
+   (%kind :initarg :kind :reader kind))
+  (:report (lambda (condition stream)
+             (format stream "~:(~a~) ~s was declared ~s, but was still used"
+                     (kind condition) (name condition) 'cl:ignore))))
+
+(define-condition unused (style-warning)
+  ((%name :initarg :name :reader name)
+   (%kind :initarg :kind :reader kind :type (member function variable)))
+  (:report (lambda (condition stream)
+             (format stream "Unused ~(~a~) ~s"
+                     (kind condition) (name condition)))))
+
+(define-condition set-unused (style-warning)
+  ((%name :initarg :name :reader name)
+   ;; In practice local function bindings cannot be modified,
+   ;; so this field is a bit pointless. It's in for symmetry.
+   (%kind :initarg :kind :reader kind :type (member function variable)))
+  (:report (lambda (condition stream)
+             (format stream "~:(~a~) ~s set but not used"
+                     (kind condition) (name condition)))))
+
 (define-condition not-function-name (program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)

--- a/compile/misc-program-conditions.lisp
+++ b/compile/misc-program-conditions.lisp
@@ -1,61 +1,61 @@
 (in-package #:maclina.compile)
 
-(define-condition bind-constant (program-error)
+(define-condition bind-constant (compiler-program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "Attempt to bind constant variable ~s"
                      (name condition)))))
 
-(define-condition go-tag-not-tag (program-error)
+(define-condition go-tag-not-tag (compiler-program-error)
   ((%tag :initarg :tag :reader tag))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid ~s tag" (tag condition) 'go))))
 
-(define-condition no-go (program-error)
+(define-condition no-go (compiler-program-error)
   ((%tag :initarg :tag :reader tag))
   (:report (lambda (condition stream)
              (format stream "Attempt to ~s to unknown tag ~s"
                      'go (tag condition)))))
 
-(define-condition block-name-not-symbol (program-error)
+(define-condition block-name-not-symbol (compiler-program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid ~s name"
                      (name condition) 'block))))
 
-(define-condition no-return (program-error)
+(define-condition no-return (compiler-program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "Attempt to ~s unknown block ~s"
                      'return-from (name condition)))))
 
-(define-condition invalid-eval-when-situation (program-error)
+(define-condition invalid-eval-when-situation (compiler-program-error)
   ((%situation :initarg :situation :reader situation))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid ~s situation"
                      (situation condition) 'eval-when))))
 
-(define-condition variable-not-symbol (program-error)
+(define-condition variable-not-symbol (compiler-program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid variable name"
                      (name condition)))))
 
-(define-condition used (style-warning)
+(define-condition used (compiler-program-style-warning)
   ((%name :initarg :name :reader name)
    (%kind :initarg :kind :reader kind))
   (:report (lambda (condition stream)
              (format stream "~:(~a~) ~s was declared ~s, but was still used"
                      (kind condition) (name condition) 'cl:ignore))))
 
-(define-condition unused (style-warning)
+(define-condition unused (compiler-program-style-warning)
   ((%name :initarg :name :reader name)
    (%kind :initarg :kind :reader kind :type (member function variable)))
   (:report (lambda (condition stream)
              (format stream "Unused ~(~a~) ~s"
                      (kind condition) (name condition)))))
 
-(define-condition set-unused (style-warning)
+(define-condition set-unused (compiler-program-style-warning)
   ((%name :initarg :name :reader name)
    ;; In practice local function bindings cannot be modified,
    ;; so this field is a bit pointless. It's in for symmetry.
@@ -64,55 +64,55 @@
              (format stream "~:(~a~) ~s set but not used"
                      (kind condition) (name condition)))))
 
-(define-condition not-function-name (program-error)
+(define-condition not-function-name (compiler-program-error)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid function name"
                      (name condition)))))
 
-(define-condition not-fnameoid (program-error)
+(define-condition not-fnameoid (compiler-program-error)
   ((%fnameoid :initarg :fnameoid :reader fnameoid))
   (:report (lambda (condition stream)
              (format stream "Parameter to ~s is not a valid function name or lambda expression: ~s"
                      'cl:function (fnameoid condition)))))
 
-(define-condition not-declaration (program-error)
+(define-condition not-declaration (compiler-program-error)
   ((%specifier :initarg :specifier :reader specifier))
   (:report (lambda (condition stream)
              (format stream "~s is not a valid declaration specifier"
                      (specifier condition)))))
 
-(define-condition setq-uneven (program-error)
+(define-condition setq-uneven (compiler-program-error)
   ((%remainder :initarg :remainder :reader remainder))
   (:report (lambda (condition stream)
              (format stream "~s given uneven number of variables and values: ~s"
                      'setq (remainder condition)))))
 
-(define-condition improper-body (program-error)
+(define-condition improper-body (compiler-program-error)
   ((%body :initarg :body :reader body))
   (:report (lambda (condition stream)
              (format stream "Body forms are not a proper list: ~s"
                      (body condition)))))
 
-(define-condition improper-arguments (program-error)
+(define-condition improper-arguments (compiler-program-error)
   ((%args :initarg :args :reader args))
   (:report (lambda (condition stream)
              (format stream "Arguments are not a proper list: ~s"
                      (args condition)))))
 
-(define-condition improper-bindings (program-error)
+(define-condition improper-bindings (compiler-program-error)
   ((%bindings :initarg :bindings :reader bindings))
   (:report (lambda (condition stream)
              (format stream "Bindings are not a proper list: ~s"
                      (bindings condition)))))
 
-(define-condition improper-situations (program-error)
+(define-condition improper-situations (compiler-program-error)
   ((%situations :initarg :situations :reader situations))
   (:report (lambda (condition stream)
              (format stream "~a situations are not a proper list: ~s"
                      'eval-when (situations condition)))))
 
-(define-condition improper-declarations (program-error)
+(define-condition improper-declarations (compiler-program-error)
   ((%declarations :initarg :declarations :reader declarations))
   (:report (lambda (condition stream)
              (format stream "Declarations are not a proper list: ~s"

--- a/compile/misc-program-conditions.lisp
+++ b/compile/misc-program-conditions.lisp
@@ -162,9 +162,10 @@
                (go again))))
     (t nil)))
 
-;;; this is alexandria:parse-body, but checks for properness first.
-(defun parse-body (body &rest keys &key documentation whole)
+;;; this is alexandria:parse-body, but checks for properness first,
+;;; and maintains source info.
+(defun parse-body (body &rest keys &key documentation whole source)
   (declare (ignore documentation whole))
   (if (proper-list-p body)
-      (apply #'alexandria:parse-body body keys)
-      (error 'improper-body :body body)))
+      (apply #'alexandria:parse-body body :allow-other-keys t keys)
+      (error 'improper-body :body body :source source)))

--- a/compile/misc-program-conditions.lisp
+++ b/compile/misc-program-conditions.lisp
@@ -41,6 +41,14 @@
              (format stream "~s is not a valid variable name"
                      (name condition)))))
 
+;;; CLHS says macrolet names are function names, but a (setf foo) name
+;;; for a macro is meaningless. DEFMACRO only accepts symbols.
+(define-condition macro-not-symbol (compiler-program-error)
+  ((%name :initarg :name :reader name))
+  (:report (lambda (condition stream)
+             (format stream "~s is not a valid macro name"
+                     (name condition)))))
+
 (define-condition used (compiler-program-style-warning)
   ((%name :initarg :name :reader name)
    (%kind :initarg :kind :reader kind))
@@ -117,6 +125,19 @@
   (:report (lambda (condition stream)
              (format stream "Declarations are not a proper list: ~s"
                      (declarations condition)))))
+
+;;; Used at compile time, so they are program-conditions
+;;; and have a SOURCE slot.
+(define-condition wrong-number-of-arguments (compiler-program-error
+                                             arg:wrong-number-of-arguments)
+  ())
+
+(define-condition odd-keywords (compiler-program-error arg:odd-keywords)
+  ())
+
+(define-condition unrecognized-keyword-argument (compiler-program-error
+                                                 arg:unrecognized-keyword-argument)
+  ())
 
 ;;; from cleavir
 (defun proper-list-p (object)

--- a/compile/package.lisp
+++ b/compile/package.lisp
@@ -31,4 +31,6 @@
            #:name
            #:unknown-reference-resolution #:resolve-reference
            #:resolve-function #:resolve-macro
-           #:assumed-function-now-macro))
+           #:assumed-function-now-macro)
+  ;; PC map info related stuff
+  (:export #:*source-locations*))

--- a/compile/package.lisp
+++ b/compile/package.lisp
@@ -27,6 +27,7 @@
            #:cfunction-lambda-list #:cfunction-lambda-list-p)
   ;; Conditions and compilation unit handling
   (:export #:with-compilation-unit #:with-compilation-results)
+  (:export #:compiler-condition #:source)
   (:export #:unknown-reference #:unknown-variable #:unknown-function
            #:name
            #:unknown-reference-resolution #:resolve-reference

--- a/compile/unknown-reference-conditions.lisp
+++ b/compile/unknown-reference-conditions.lisp
@@ -10,14 +10,15 @@
 (defun warn-unknown (datum &rest arguments)
   (restart-case (apply #'warn datum arguments) (continue ())))
 
-(define-condition unknown-variable (unknown-reference warning)
+(define-condition unknown-variable (unknown-reference compiler-program-warning)
   ()
   (:report (lambda (condition stream)
              (format stream "Unknown variable ~s: treating as special"
                      (name condition))))
   (:documentation "Condition signaled when the compiler encounters an unknown variable."))
 
-(define-condition unknown-function (unknown-reference style-warning)
+(define-condition unknown-function (unknown-reference
+                                    compiler-program-style-warning)
   ()
   (:report (lambda (condition stream)
              (format stream "Unknown operator ~s: treating as global function"
@@ -41,7 +42,7 @@
 (defmethod resolve-reference ((r1 resolve-function) (r2 unknown-function))
   (equal (name r1) (name r2)))
 
-(define-condition assumed-function-now-macro (warning)
+(define-condition assumed-function-now-macro (compiler-program-warning)
   ((%name :initarg :name :reader name))
   (:report (lambda (condition stream)
              (format stream "Uses of newly noted macro ~s were previously assumed to be function calls"
@@ -53,5 +54,5 @@
   (:documentation "Condition that can be SIGNALed to indicate to a compilation unit that a new macro has been defined, and that previously unknown references to an operator by that name can now be resolved."))
 (defmethod resolve-reference ((r1 resolve-macro) (r2 unknown-function))
   (when (equal (name r1) (name r2))
-    (warn 'assumed-function-now-macro :name (name r1))
+    (warn 'assumed-function-now-macro :name (name r1) :source (source r2))
     t))

--- a/machine.lisp
+++ b/machine.lisp
@@ -23,7 +23,12 @@
 	   #:fdefinition #:fmakunbound #:fboundp)
   (:export #:lambda-parameters-limit #:call-arguments-limit
            #:lambda-list-keywords #:multiple-values-limit)
-  (:export #:disassemble #:display-instruction))
+  (:export #:disassemble #:display-instruction)
+  ;; PC map stuff
+  (:export #:bytecode-module-pc-map
+           #:map-info #:start #:end
+           #:source-info #:source)
+  (:export #:info-at #:most-specific-info-at #:source-at))
 
 ;;;; Definition of the virtual machine, used by both the compiler and the VM.
 

--- a/maclina.asd
+++ b/maclina.asd
@@ -120,6 +120,7 @@
                  (:file "cooperation" :depends-on ("suites" "rt" "packages"))
                  (:file "timeout" :depends-on ("suites" "rt" "packages"))
                  (:file "long" :depends-on ("suites" "rt" "packages"))
+                 (:file "pc-map" :depends-on ("suites" "rt" "packages"))
                  (:file "ignore" :depends-on ("suites" "rt" "packages"))
                  (:module "compiler-conditions"
                   :depends-on ("suites" "rt" "packages")

--- a/maclina.asd
+++ b/maclina.asd
@@ -119,6 +119,7 @@
                  (:file "cooperation" :depends-on ("suites" "rt" "packages"))
                  (:file "timeout" :depends-on ("suites" "rt" "packages"))
                  (:file "long" :depends-on ("suites" "rt" "packages"))
+                 (:file "ignore" :depends-on ("suites" "rt" "packages"))
                  (:module "compiler-conditions"
                   :depends-on ("suites" "rt" "packages")
                   :components ((:file "reference")

--- a/maclina.asd
+++ b/maclina.asd
@@ -39,10 +39,11 @@
                  (:file "unknown-reference-conditions" :depends-on ("package"))
                  (:file "compilation-unit"
                   :depends-on ("unknown-reference-conditions" "package"))
+                 (:file "environment" :depends-on ("package"))
                  (:file "compile" :depends-on ("unknown-reference-conditions"
                                                "misc-program-conditions"
                                                "compilation-unit" "parse-macro"
-                                               "package"))
+                                               "environment" "package"))
                  (:file "documentation" :depends-on ("compile"))))))
 
 (asdf:defsystem #:maclina/compile-file

--- a/maclina.asd
+++ b/maclina.asd
@@ -20,6 +20,7 @@
   :components ((:file "machine")
                (:file "arg-conditions")
                (:file "structures" :depends-on ("machine"))
+               (:file "map-info" :depends-on ("structures" "machine"))
                (:file "link" :depends-on ("machine"))
                (:file "access" :depends-on ("machine"))
                (:file "disassemble" :depends-on ("structures" "machine"))))

--- a/maclina.asd
+++ b/maclina.asd
@@ -34,10 +34,13 @@
   :components
   ((:module "compile"
     :components ((:file "package")
-                 (:file "misc-program-conditions" :depends-on ("package"))
+                 (:file "conditions" :depends-on ("package"))
+                 (:file "misc-program-conditions"
+                  :depends-on ("conditions" "package"))
                  (:file "parse-macro" :depends-on ("misc-program-conditions"
                                                    "package"))
-                 (:file "unknown-reference-conditions" :depends-on ("package"))
+                 (:file "unknown-reference-conditions"
+                  :depends-on ("conditions" "package"))
                  (:file "compilation-unit"
                   :depends-on ("unknown-reference-conditions" "package"))
                  (:file "environment" :depends-on ("package"))

--- a/map-info.lisp
+++ b/map-info.lisp
@@ -1,0 +1,59 @@
+(in-package #:maclina.machine)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Map infos: Things in the PC map.
+;;; These have a start and end index as well as accessory information.
+;;; They are used for debug information as well as information about the
+;;; original structure of Lisp programs.
+
+;;; The compiler generates infos with a few convenient restrictions:
+;;; 1) Info ranges are nested. That is, if one range intersects another,
+;;;    at least one of the ranges contains the entirety of the other.
+;;; 2) Infos are sorted in the map by start and then by end. That is, iff
+;;;    info1 appears before info2 in the map, either info1's start is < that of
+;;;    info2, or they are = and info1's end is <= that of info2. Infos with
+;;;    the same start and end are ordered indeterminately.
+
+(defclass map-info ()
+  (;; During compilation, these will be labels. The accessors are them used
+   ;; to make them into actual indices. The writers should not be used
+   ;; outside of link-pc-map in the compiler.
+   (%start :initarg :start :accessor start)
+   (%end :initarg :end :accessor end)))
+
+(defclass source-info (map-info)
+  ((%source :initarg :source :reader source)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; Convenience accessors
+;;;
+
+;;; Return a list of all infos for the given PC. Most specific infos first.
+(defun info-at (module pc)
+  (loop with result = ()
+        for info across (bytecode-module-pc-map module)
+        until (< pc (start info))
+        when (< pc (end info))
+          do (cl:push info result)
+        finally (cl:return result)))
+
+;;; Get the most specific info matching the predicate, for the given PC.
+(defun most-specific-info-at (module pc predicate)
+  (loop with best = ()
+        for info across (bytecode-module-pc-map module)
+        for end = (end info)
+        until (< pc (start info))
+        when (and (< pc end)
+                  (funcall predicate info)
+                  (or (null best) (< end (end best))))
+          do (setf best info)
+        finally (cl:return info)))
+
+(defun source-at (module pc)
+  (let ((info (most-specific-info-at
+               module pc (lambda (info) (typep info 'source-info)))))
+    (if info
+        (source info)
+        nil)))

--- a/structures.lisp
+++ b/structures.lisp
@@ -4,7 +4,8 @@
 
 (defstruct bytecode-module
   bytecode
-  literals)
+  literals
+  pc-map)
 
 (defclass bytecode-function (closer-mop:funcallable-standard-object)
   ((%module :initarg :module :accessor bytecode-function-module)

--- a/test/compiler-conditions/reference.lisp
+++ b/test/compiler-conditions/reference.lisp
@@ -4,8 +4,11 @@
 (5am:in-suite unknown-reference-conditions)
 
 (5am:test unknown-variable-read
-  (let ((var (make-symbol "UNKNOWN-VARIABLE"))
-        warning)
+  (let* ((var (make-symbol "UNKNOWN-VARIABLE"))
+         (form `(progn ,var))
+         (maclina.compile:*source-locations* (make-hash-table))
+         warning)
+    (setf (gethash form maclina.compile:*source-locations*) 37)
     (multiple-value-bind (fun warningsp failurep)
         (handler-bind
             ((maclina.compile:unknown-variable
@@ -13,12 +16,14 @@
                  (setq warning w)
                  ;; Make sure we still fail with a MUFFLE-WARNING.
                  (muffle-warning w))))
-          (ccompile nil `(lambda () ,var)))
+          (ccompile nil `(lambda () ,form)))
       (5am:is-true warningsp "COMPILE did not report a warning")
       (5am:is-true failurep "COMPILE did not fail")
       (5am:is-true warning "COMPILE did not signal a warning")
       (5am:is (eql var (maclina.compile:name warning))
               "COMPILE's warning did not have the correct name")
+      (5am:is (eql 37 (maclina.compile:source warning))
+              "COMPILE's warning did not have a source location")
       (5am:signals unbound-variable (funcall fun))
       ;; Now make sure it was assumed to be a special variable.
       (handler-case
@@ -30,18 +35,23 @@
           (5am:fail "Unknown variable was not assumed to be special"))))))
 
 (5am:test unknown-variable-write
-  (let ((var (make-symbol "UNKNOWN-VARIABLE"))
-        warning)
+  (let* ((var (make-symbol "UNKNOWN-VARIABLE"))
+         (form `(setq ,var val))
+         (maclina.compile:*source-locations* (make-hash-table))
+         warning)
+    (setf (gethash form maclina.compile:*source-locations*) 92)
     (multiple-value-bind (fun warningsp failurep)
         (handler-bind
             ((maclina.compile:unknown-variable
                (lambda (w) (setq warning w) (muffle-warning w))))
-          (ccompile nil `(lambda (val) (setq ,var val))))
+          (ccompile nil `(lambda (val) ,form)))
       (5am:is-true warningsp "COMPILE did not report a warning")
       (5am:is-true failurep "COMPILE did not fail")
       (5am:is-true warning "COMPILE did not signal a warning")
       (5am:is (eql var (maclina.compile:name warning))
               "COMPILE's warning did not have the correct name")
+      (5am:is (eql 92 (maclina.compile:source warning))
+              "COMPILE's warning did not have a source location")
       (handler-case
           (let ((val (ceval `(let ((,var 71))
                                (declare (special ,var))
@@ -52,17 +62,22 @@
           (5am:fail "Unknown variable was not assumed to be special"))))))
 
 (5am:test unknown-function
-  (let ((fname (make-symbol "UNKNOWN-FUNCTION")) warning)
+  (let* ((fname (make-symbol "UNKNOWN-FUNCTION")) warning
+         (form `(,fname))
+         (maclina.compile:*source-locations* (make-hash-table)))
+    (setf (gethash form maclina.compile:*source-locations*) 81)
     (multiple-value-bind (fun warningsp failurep)
         (handler-bind
             ((maclina.compile:unknown-function
                (lambda (w) (setq warning w) (muffle-warning w))))
-          (ccompile nil `(lambda () (,fname))))
+          (ccompile nil `(lambda () ,form)))
       (5am:is-true warningsp "COMPILE did not report a warning")
       (5am:is-false failurep "COMPILE failed")
       (5am:is-true warning "COMPILE did not signal a warning")
       (5am:is (eql fname (maclina.compile:name warning))
               "COMPILE's warning did not have the correct name")
+      (5am:is (eql 81 (maclina.compile:source warning))
+              "COMPILE's warning did not have a source location")
       (5am:signals undefined-function (funcall fun)))))
 
 (5am:test resolve-unknown-function
@@ -81,13 +96,22 @@
                   "Unknown function resolution failed: ~s signaled" warning)))
 
 (5am:test resolve-unknown-macro
-  (5am:signals
-      maclina.compile:assumed-function-now-macro
+  (let* ((mname (make-symbol "UNKNOWN-MACRO"))
+         (form `(,mname))
+         (maclina.compile:*source-locations* (make-hash-table))
+         warning)
+    (setf (gethash form maclina.compile:*source-locations*) 20)
+    (handler-bind
+        ((warning (lambda (w) (setq warning w) (muffle-warning w))))
       (maclina.compile:with-compilation-unit (:override t)
-        (let ((mname (make-symbol "UNKNOWN-MACRO")))
-          (multiple-value-bind (_ warningsp failurep)
-              (ccompile nil `(lambda () (,mname)))
-            (declare (ignore _))
-            (5am:is-false warningsp "COMPILE reported warning too early")
-            (5am:is-false failurep "COMPILE reported failure too early"))
-          (signal 'maclina.compile:resolve-macro :name mname)))))
+        (multiple-value-bind (_ warningsp failurep)
+            (ccompile nil `(lambda () ,form))
+          (declare (ignore _))
+          (5am:is-false warningsp "COMPILE reported warning too early")
+          (5am:is-false failurep "COMPILE reported failure too early"))
+        (signal 'maclina.compile:resolve-macro :name mname)))
+    (5am:is-true (typep warning 'maclina.compile:assumed-function-now-macro)
+                 "WITH-COMPILATION-UNIT did not signal an ~s warning"
+                 'maclina.compile:assumed-function-now-macro)
+    (5am:is (eql 20 (maclina.compile:source warning))
+            "WITH-COMPILATION-UNIT's warning did not have a source location")))

--- a/test/ignore.lisp
+++ b/test/ignore.lisp
@@ -1,0 +1,103 @@
+(in-package #:maclina.test)
+
+;;;; This file tests more pedantic behavior on IGNORE:
+;;;; that Maclina complains when a variable is unused, and so on.
+;;;; This is not required by the standard so it is not in the ANSI tests.
+
+;;; we use .warn in order to avoid conflict with the ANSI ignore suite.
+(5am:def-suite ignore.warn :in maclina)
+(5am:in-suite ignore.warn)
+
+(defmacro test-style (lambda-expression)
+  `(progn
+     (5am:signals style-warning (ccompile nil ',lambda-expression))
+     (5am:is (not (null (nth-value 1 (ccompile nil ',lambda-expression))))
+             "~s compiled with no warnings" ',lambda-expression)
+     (5am:is (null (nth-value 2 (ccompile nil ',lambda-expression)))
+             "~s compiled with errors" ',lambda-expression)))
+
+(defmacro test-nostyle (lambda-expression)
+  `(progn
+     (5am:is (eql t (handler-case (progn (ccompile nil ',lambda-expression) t)
+                      (style-warning () nil)))
+             "Compiling ~s signaled a style-warning" ',lambda-expression)
+     (5am:is (null (nth-value 1 (ccompile nil ',lambda-expression)))
+             "~s compiled with warnings" ',lambda-expression)
+     (5am:is (null (nth-value 1 (ccompile nil ',lambda-expression)))
+             "~s compiled with errors" ',lambda-expression)))
+
+(5am:test noignore
+  (test-style (lambda (x)))
+  (test-style (lambda (&optional x)))
+  (test-style (lambda (&optional (x nil xp)) x))
+  (test-style (lambda (&rest r)))
+  (test-style (lambda (&key k)))
+  (test-style (lambda (&key (k nil kp)) k))
+  (test-style (lambda () (let ((y 7)))))
+  (test-style (lambda () (let* ((y 7)))))
+  (test-style (lambda () (flet ((foo ())))))
+  (test-style (lambda () (labels ((foo ())))))
+  (test-nostyle (lambda (x) x))
+  (test-nostyle (lambda (&optional x) x))
+  ;; this also tests 0 contexts, which is important as the compiler
+  ;; tends to skip a lot of work there.
+  (test-nostyle (lambda (&optional (x nil xp)) (progn x xp)))
+  (test-nostyle (lambda (&rest r) r))
+  (test-nostyle (lambda (&key k) k))
+  (test-nostyle (lambda (&key (k nil kp)) (progn k kp)))
+  (test-nostyle (lambda () (let ((y 7)) y)))
+  (test-nostyle (lambda () (let* ((y 7)) y)))
+  (test-nostyle (lambda () (flet ((foo ())) (foo))))
+  (test-nostyle (lambda () (flet ((foo ())) #'foo)))
+  (test-nostyle (lambda () (labels ((foo ())) (foo))))
+  (test-nostyle (lambda () (labels ((foo ())) #'foo))))
+
+(5am:test ignore
+  (test-nostyle (lambda (x) (declare (ignore x))))
+  (test-nostyle (lambda (&optional x) (declare (ignore x))))
+  (test-nostyle (lambda (&optional (x nil xp)) (declare (ignore xp)) x))
+  (test-nostyle (lambda (&rest r) (declare (ignore r))))
+  (test-nostyle (lambda (&key k) (declare (ignore k))))
+  (test-nostyle (lambda (&key (k nil kp)) (declare (ignore kp)) k))
+  (test-nostyle (lambda () (let ((y 7)) (declare (ignore y)))))
+  (test-nostyle (lambda () (let* ((y 7)) (declare (ignore y)))))
+  (test-nostyle (lambda () (flet ((foo ())) (declare (ignore #'foo)))))
+  (test-nostyle (lambda () (labels ((foo ())) (declare (ignore #'foo)))))
+  (test-style (lambda (x) (declare (ignore x)) x))
+  (test-style (lambda (&optional x) (declare (ignore x)) x))
+  ;; this also tests 0 contexts, which is important as the compiler
+  ;; tends to skip a lot of work there.
+  (test-style (lambda (&optional (x nil xp)) (declare (ignore x)) (progn x xp)))
+  (test-style (lambda (&rest r) (declare (ignore r)) r))
+  (test-style (lambda (&key k) (declare (ignore k)) k))
+  (test-style (lambda (&key (k nil kp)) (declare (ignore k)) (progn k kp)))
+  (test-style (lambda () (let ((y 7)) (declare (ignore y)) y)))
+  (test-style (lambda () (let* ((y 7)) (declare (ignore y)) y)))
+  (test-style (lambda () (flet ((foo ())) (declare (ignore #'foo)) (foo))))
+  (test-style (lambda () (flet ((foo ())) (declare (ignore #'foo)) #'foo)))
+  (test-style (lambda () (labels ((foo ())) (declare (ignore #'foo)) (foo))))
+  (test-style (lambda () (labels ((foo ())) (declare (ignore #'foo)) #'foo))))
+
+(5am:test ignorable
+  (test-nostyle (lambda (x) (declare (ignorable x))))
+  (test-nostyle (lambda (&optional x) (declare (ignorable x))))
+  (test-nostyle (lambda (&optional (x nil xp)) (declare (ignorable xp)) x))
+  (test-nostyle (lambda (&rest r) (declare (ignorable r))))
+  (test-nostyle (lambda (&key k) (declare (ignorable k))))
+  (test-nostyle (lambda (&key (k nil kp)) (declare (ignorable kp)) k))
+  (test-nostyle (lambda () (let ((y 7)) (declare (ignorable y)))))
+  (test-nostyle (lambda () (let* ((y 7)) (declare (ignorable y)))))
+  (test-nostyle (lambda () (flet ((foo ())) (declare (ignorable #'foo)))))
+  (test-nostyle (lambda () (labels ((foo ())) (declare (ignorable #'foo)))))
+  (test-nostyle (lambda (x) (declare (ignorable x)) x))
+  (test-nostyle (lambda (&optional x) (declare (ignorable x)) x))
+  (test-nostyle (lambda (&optional (x nil xp)) (declare (ignorable x)) (progn x xp)))
+  (test-nostyle (lambda (&rest r) (declare (ignorable r)) r))
+  (test-nostyle (lambda (&key k) (declare (ignorable k)) k))
+  (test-nostyle (lambda (&key (k nil kp)) (declare (ignorable k)) (progn k kp)))
+  (test-nostyle (lambda () (let ((y 7)) (declare (ignorable y)) y)))
+  (test-nostyle (lambda () (let* ((y 7)) (declare (ignorable y)) y)))
+  (test-nostyle (lambda () (flet ((foo ())) (declare (ignorable #'foo)) (foo))))
+  (test-nostyle (lambda () (flet ((foo ())) (declare (ignorable #'foo)) #'foo)))
+  (test-nostyle (lambda () (labels ((foo ())) (declare (ignorable #'foo)) (foo))))
+  (test-nostyle (lambda () (labels ((foo ())) (declare (ignorable #'foo)) #'foo))))

--- a/test/pc-map.lisp
+++ b/test/pc-map.lisp
@@ -1,0 +1,62 @@
+(in-package #:maclina.test)
+
+;;; Tests of PC-mapped information, like source locations.
+
+(5am:def-suite pc-map :in maclina)
+(5am:in-suite pc-map)
+
+;;; Pending a clean way to get PCs corresponding to executing forms
+;;; (like from backtraces), we basically just test that infos are
+;;; present and properly nested.
+
+(5am:test source
+  (let* ((sources (make-hash-table))
+         (add '(+ x y))
+         (add2 `(+ ,add z)))
+    (setf (gethash add sources) 13 ; arbitrary "source locations"
+          (gethash add2 sources) 9)
+    (let* ((maclina.compile:*source-locations* sources)
+           (f (ccompile nil `(lambda (x y z) ,add2)))
+           (mod (maclina.machine:bytecode-function-module f))
+           (outerp nil) (innerp nil))
+      ;; Weird state machine. We want :before :add2 :add :add2-after :after,
+      ;; except these can be abbreviated (if sources begin or end simultaneously).
+      (loop with state = :before
+            with success = t
+            for pc below (length (maclina.machine:bytecode-module-bytecode mod))
+            for source = (maclina.machine:source-at mod pc)
+            do (case source
+                 ((nil)
+                  (case state
+                    ((:before :after))
+                    ((:add2)
+                     (5am:fail "Missing source info for inner form")
+                     (setf success nil) (loop-finish))
+                    ((:add :add2-after) (setf state :after))))
+                 (9
+                  (setf outerp t)
+                  (case state
+                    ((:before) (setf state :add2))
+                    ((:add2 :add2-after))
+                    ((:add) (setf state :add2-after))
+                    ((:after)
+                     (5am:fail "Source info resumes after ending")
+                     (setf success nil) (loop-finish))))
+                 (13
+                  (setf innerp t)
+                  (case state
+                    ((:before :add2) (setf state :add))
+                    ((:add))
+                    ((:add2-after :after)
+                     (5am:fail "Source info resumes after ending")
+                     (setf success nil) (loop-finish))))
+                 (otherwise
+                  (5am:fail "Unexpected source location ~s" source)
+                  (setf success nil) (loop-finish)))
+            finally (when success (5am:pass)))
+      (if outerp
+          (5am:pass)
+          (5am:fail "Missing source info for outer call"))
+      (if innerp
+          (5am:pass)
+          (5am:fail "Missing source info for inner call")))))

--- a/test/pc-map.lisp
+++ b/test/pc-map.lisp
@@ -54,9 +54,5 @@
                   (5am:fail "Unexpected source location ~s" source)
                   (setf success nil) (loop-finish)))
             finally (when success (5am:pass)))
-      (if outerp
-          (5am:pass)
-          (5am:fail "Missing source info for outer call"))
-      (if innerp
-          (5am:pass)
-          (5am:fail "Missing source info for inner call")))))
+      (5am:is-true outerp "Missing source info for outer call")
+      (5am:is-true innerp "Missing source info for inner call"))))


### PR DESCRIPTION
Starts on instruction-mapped info in the form of source locations.

Very incomplete: in particular there is no FASL support (i.e. FASLs dump fine but lack source info).